### PR TITLE
chore: add native-release-sync dispatch + CODEOWNERS + sync skills

### DIFF
--- a/.claude/skills/clevertap-expo-plugin-dev/SKILL.md
+++ b/.claude/skills/clevertap-expo-plugin-dev/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: clevertap-expo-plugin-dev
+description: Guides development of the CleverTap Expo config plugin (@clevertap/clevertap-expo-plugin) — adding new features, modifying Android/iOS native config, debugging prebuild issues, and reviewing changes. Covers the plugin's modifier chain, MetadataConfig pattern, gradle property system, iOS extension creation, and native Kotlin lifecycle code. Use when adding features, fixing bugs, reviewing PRs, or modifying any file in this codebase.
+---
+
+# CleverTap Expo Plugin — Development Guide
+
+## Additional Resources
+
+- [android-reference.md](android-reference.md) — Android modifier patterns: manifest MetadataConfig, gradle, resources, file copy, dependency templates
+- [ios-reference.md](ios-reference.md) — iOS modifier patterns: plist, AppDelegate, Podfile, Xcode project, NSE/NCE extensions
+- [config-reference.md](config-reference.md) — Full configuration schema, type definitions, and how to add new config options
+- [Expo SDK Upgrade Skill](../expo-sdk-upgrade/SKILL.md) — Workflow for upgrading the plugin when a new Expo SDK or clevertap-react-native version is released. Includes version catalog diffing methodology and detailed migration plan output format.
+
+---
+
+## I. Architecture
+
+### Entry Point
+
+```
+app.plugin.js → build/src/withClevertap.js (compiled from src/withClevertap.ts)
+```
+
+### Modifier Chain
+
+```
+withClevertap(config, props)
+├── withCleverTapAndroid(config, props)            [src/withCleverTapAndroid.ts]
+│   ├── withHuaweiConfig                           (copies agconnect-services.json if HMS enabled)
+│   ├── withCustomNotificationSound                (copies sound file(s) to res/raw)
+│   ├── withCleverTapAndroidResources              (writes strings.xml: logLevel, lifecycle, pushTemplates)
+│   ├── withCleverTapAndroidManifest               (metadata via MetadataConfig[], services, permissions)
+│   ├── withClevertapAndroidAppBuildGradle         (app/build.gradle deps + gradle.properties)
+│   └── withCleverTapRootGradlePlugin
+│       ├── withCleverTapSettingsGradle            (Huawei Maven repo in settings.gradle)
+│       └── withCleverTapRootGradle                (root build.gradle classpaths + HMS repos)
+│
+└── withCleverTapIos(config, props)                [src/withClevertapIos.ts]
+    ├── withCleverTapInfoPlist                     (credentials, background modes)
+    ├── withCleverTapBridgingHeader                (ObjC bridging header)
+    ├── withCleverTapNotificationServiceExtension  (NSE: files + Xcode target, if enabled)
+    ├── withCleverTapNotificationContentExtension  (NCE: files + Xcode target, if enabled)
+    └── withCleverTapPodfile                       (clevertap-react-native pod + extension pods)
+```
+
+### Expo Config Plugin APIs Used
+
+| API | Safe? | Used for |
+|-----|-------|---------|
+| `withAndroidManifest` | Yes | Metadata, FCM service, CTNotificationIntentService, permissions |
+| `withStringsXml` | Yes | logLevel, lifecycle callbacks, push templates flag |
+| `withAppBuildGradle` | Yes | Dependencies via `mergeContents` |
+| `withGradleProperties` | Yes | Feature flags and dependency versions |
+| `withProjectBuildGradle` | Yes | Root classpaths and HMS repos |
+| `withSettingsGradle` | Yes | Huawei Maven repository |
+| `withInfoPlist` | Yes | CleverTap credentials, UIBackgroundModes |
+| `withXcodeProject` | Yes | NSE and NCE target creation |
+| `withDangerousMod` | **No** | Podfile text manipulation, file copy operations |
+
+---
+
+## II. File Organization
+
+```
+src/
+├── withClevertap.ts                         # Root plugin — validates props, chains Android + iOS
+├── withCleverTapAndroid.ts                  # Android orchestrator
+├── withClevertapIos.ts                      # iOS orchestrator
+│
+├── android_config/
+│   ├── gradle/
+│   │   ├── withClevertapAndroidAppBuildGradle.ts    # app/build.gradle + gradle.properties
+│   │   └── withCleverTapAndroidAppRootBuildGradle.ts # root build.gradle + settings.gradle
+│   ├── manifest/
+│   │   └── withCleverTapAndroidManifest.ts          # AndroidManifest.xml (MetadataConfig pattern)
+│   ├── res/
+│   │   └── withCleverTapAndroidResources.ts         # strings.xml (logLevel, lifecycle, pushTemplates)
+│   ├── io/
+│   │   └── withCleverTapAndroidCopyFiles.ts         # HMS config + custom sounds
+│   └── utility/
+│       ├── androidAppDepsTemplate.ts                # Gradle dependency template generator
+│       ├── constants.ts                             # Gradle property keys + default versions
+│       └── utils.ts                                 # Gradle property creation helpers
+│
+└── iOS_config/
+    ├── FileManager.ts                               # Async file read/write/copy
+    ├── IOSConstants.ts                              # iOS target names, podfile snippets, regex
+    ├── NSUpdaterManager.ts                          # Updates bundle versions in extension plists
+    ├── withCleverTapBridgingHeader.ts               # Adds ObjC bridging header
+    ├── withCleverTapInfoPlist.ts                    # Info.plist modifier
+    ├── withCleverTapNotificationContentExtension.ts # NCE Xcode target + file copy
+    ├── withCleverTapNotificationServiceExtension.ts # NSE Xcode target + file copy
+    └── withCleverTapPodfile.ts                      # Podfile modifications
+
+types/
+├── types.ts              # CleverTapPluginProps (root config type)
+├── androidTypes.ts       # Android, Features, Dependencies interfaces
+└── iOSTypes.ts           # iOS interface
+
+support/
+└── CleverTapLog.ts       # Logging: CleverTapLog.log() / .error()
+
+android/src/main/java/expo/modules/adapters/clevertap/
+├── CleverTapPackage.kt                              # Expo Package — registers lifecycle listeners
+├── CleverTapReactApplicationLifecycleListener.kt   # App onCreate: SDK init, push templates
+├── CleverTapReactActivityLifecycleListener.kt      # Activity lifecycle: notification dismiss
+└── NotificationUtils.kt                            # Notification dismiss helper (Android 12+)
+
+CTExample/                                          # Example app (replaces example/)
+├── app.json                                        # Plugin config with all options
+└── App.tsx
+```
+
+---
+
+## III. Key Patterns
+
+### MetadataConfig Pattern (Android Manifest)
+
+All manifest metadata is managed via a declarative `MetadataConfig[]` array. Each entry defines:
+- `key` — Android metadata key
+- `getValue(props, config)` — returns value string or `undefined` (undefined = remove)
+- `onAdd(props, manifest)` — optional: add permissions, etc. when value is set
+- `onRemove(manifest)` — optional: clean up permissions when value is removed
+
+**This is bidirectional** — entries are removed from the manifest when a feature is disabled, unlike a simple append approach.
+
+To add a new metadata entry, add to `METADATA_CONFIGS` in `src/android_config/manifest/withCleverTapAndroidManifest.ts`.
+
+### strings.xml Resources Pattern
+
+`withCleverTapAndroidResources.ts` uses `withStringsXml` to write Android resource strings read by the native Kotlin module at runtime. Currently manages:
+- `expo_clevertap_register_activity_lifecycle_callbacks`
+- `expo_clevertap_enable_push_templates`
+- `expo_clevertap_log_level`
+
+The Kotlin module reads these from `R.bool` and `R.integer` at `Application.onCreate()`.
+
+### Gradle Properties System
+
+Feature flags and dependency versions are written to `gradle.properties`. At Gradle build time, dependencies conditionally include themselves based on `project.hasProperty()` checks. This avoids complex Gradle string manipulation for optional dependencies.
+
+---
+
+## IV. How to Add a New Android Feature Flag
+
+Example: adding `enableGeofence`.
+
+### 1. `types/androidTypes.ts` → `Features`
+```typescript
+enableGeofence?: boolean;
+```
+If it needs a version: add to `Dependencies` too.
+
+### 2. `src/android_config/utility/constants.ts`
+```typescript
+GEOFENCE_ENABLED: 'clevertapGeofenceEnabled',
+GEOFENCE_VERSION: 'geofenceVersion',
+```
+Add default version to `CLEVERTAP_DEPENDENCIES_DEFAULT_VERSIONS`.
+
+### 3. `src/android_config/utility/utils.ts` → `createFeatureProperties`
+```typescript
+createGradleProperty(KEYS.GEOFENCE_ENABLED, String(features.enableGeofence)),
+```
+
+### 4. `src/android_config/utility/androidAppDepsTemplate.ts`
+Add `generateGeofenceDependencies()` and include in `generateDependenciesTemplate()`.
+
+### 5. `src/android_config/gradle/withClevertapAndroidAppBuildGradle.ts`
+Add `enableGeofence = false` to destructured features.
+
+### 6. `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts`
+Add `enableGeofence = false` to destructured features in `withCleverTapRootGradlePlugin`.
+
+### 7. `src/android_config/manifest/withCleverTapAndroidManifest.ts` (if needs manifest entry)
+Add to `METADATA_CONFIGS`:
+```typescript
+{
+    key: 'CLEVERTAP_GEOFENCE',
+    getValue: (props) => props.android?.features?.enableGeofence ? "1" : undefined
+}
+```
+
+### 8. `CTExample/app.json` — add to plugin config for testing.
+
+---
+
+## V. How to Add a New Root Config Option
+
+Root config options affect both platforms or are cross-cutting (like `proxyDomain`, `encryptionLevel`).
+
+1. Add to `CleverTapPluginProps` in `types/types.ts`
+2. For Android manifest: add to `METADATA_CONFIGS` in `withCleverTapAndroidManifest.ts`
+3. For iOS: add to appropriate iOS modifier
+4. For strings.xml: add to `withCleverTapAndroidResources.ts` if it needs to be read at runtime by native Kotlin code
+
+---
+
+## VI. Native Kotlin Module (android/)
+
+- **`CleverTapPackage`** — implements Expo's `Package` interface; registers both lifecycle listeners
+- **`CleverTapReactApplicationLifecycleListener`** — runs in `Application.onCreate()`:
+  - Reads `R.bool.expo_clevertap_register_activity_lifecycle_callbacks` → registers `ActivityLifecycleCallback`
+  - Reads `R.integer.expo_clevertap_log_level` → sets CleverTap debug level
+  - Reads `R.bool.expo_clevertap_enable_push_templates` → sets `PushTemplateNotificationHandler`
+  - Calls `CleverTapRnAPI.initReactNativeIntegration(application)`
+- **`CleverTapReactActivityLifecycleListener`** — handles Android 12+ notification dismissal, push template notification cancellation (rating, product_display)
+- **`NotificationUtils`** — singleton for notification dismiss logic
+
+Resources (strings.xml values) are written by `withCleverTapAndroidResources` at prebuild time and read by the Kotlin module at runtime.
+
+---
+
+## VII. Testing Workflow
+
+```bash
+# Build plugin
+npm run build
+
+# Test with example app
+cd CTExample
+npx expo prebuild --clean
+npx expo run:android
+npx expo run:ios
+```
+
+After `expo prebuild`, verify:
+- `CTExample/android/app/src/main/AndroidManifest.xml` — metadata, services
+- `CTExample/android/app/build.gradle` — dependencies
+- `CTExample/android/gradle.properties` — feature flags + versions
+- `CTExample/android/app/src/main/res/values/strings.xml` — logLevel, lifecycle, pushTemplates
+- `CTExample/ios/Podfile` — pods
+- `CTExample/ios/<AppName>/Info.plist` — credentials
+
+---
+
+## VIII. Code Conventions
+
+- **Logging**: always `CleverTapLog.log()` / `.error()` — never raw `console.log`
+- **Manifest metadata**: use the `MetadataConfig` array pattern — never add raw if/else blocks
+- **Feature flags**: boolean → `gradle.properties` → Gradle conditional → runtime dependency
+- **Gradle modifications**: use `mergeContents` with tagged blocks for idempotency
+- **Naming**: use `CleverTap` (uppercase T) for new files; existing inconsistency (`withClevertap`) is kept for backward compat in public filenames
+
+---
+
+## IX. Common Pitfalls
+
+1. **strings.xml is the bridge to native** — `withCleverTapAndroidResources` must be called for any config value read by the Kotlin module at runtime
+2. **MetadataConfig removes on disable** — unlike the old approach, disabling a feature removes its manifest entry; test both enable and disable cases
+3. **Gradle classpath is only added when feature is enabled** — `google-services` classpath is only added when `enablePush=true`, not unconditionally
+4. **`withDangerousMod` ordering** — runs after safe mods; Podfile is written last
+5. **Build before test** — plugin runs from `build/`; always `npm run build` before `expo prebuild`
+6. **`customNotificationSound` accepts `string | string[]`** — handle both cases in copy logic

--- a/.claude/skills/clevertap-expo-plugin-dev/android-reference.md
+++ b/.claude/skills/clevertap-expo-plugin-dev/android-reference.md
@@ -1,0 +1,204 @@
+# Android Reference — CleverTap Expo Plugin
+
+## 1. Manifest (MetadataConfig Pattern)
+
+File: `src/android_config/manifest/withCleverTapAndroidManifest.ts`
+
+All manifest metadata is managed via a single `METADATA_CONFIGS` array. Each entry is:
+
+```typescript
+interface MetadataConfig {
+    key: string;                                          // AndroidManifest meta-data key
+    getValue: (props, config?) => string | undefined;    // undefined = REMOVE the entry
+    onAdd?: (props, androidManifest) => void;            // called on add (e.g., add permission)
+    onRemove?: (androidManifest) => void;                // called on remove (e.g., remove permission)
+}
+```
+
+This is **bidirectional**: disabling a feature removes its manifest entry and associated side effects.
+
+### Current Metadata Entries
+
+| Key | Value Source | Side Effects |
+|-----|-------------|--------------|
+| `CLEVERTAP_ACCOUNT_ID` | `props.accountId` | — |
+| `CLEVERTAP_TOKEN` | `props.accountToken` | — |
+| `CLEVERTAP_REGION` | `props.accountRegion` | — |
+| `CLEVERTAP_USE_GOOGLE_AD_ID` | `"1"` if `enableGoogleAdId` | +/- `com.google.android.gms.permission.AD_ID` |
+| `CLEVERTAP_IDENTIFIER` | `props.customIdentifiers` | — |
+| `CLEVERTAP_NOTIFICATION_ICON` | `"notification_icon.png"` if `config.notification.icon` set | — |
+| `CLEVERTAP_BACKGROUND_SYNC` | `props.android.backgroundSync` | — |
+| `CLEVERTAP_DEFAULT_CHANNEL_ID` | `props.android.defaultNotificationChannelId` | — |
+| `CLEVERTAP_INAPP_EXCLUDE` | `props.android.inAppExcludeActivities` | — |
+| `CLEVERTAP_PROXY_DOMAIN` | `props.proxyDomain` | — |
+| `CLEVERTAP_SPIKY_PROXY_DOMAIN` | `props.spikyProxyDomain` | — |
+| `CLEVERTAP_ENCRYPTION_LEVEL` | `props.encryptionLevel.toString()` | — |
+| `CLEVERTAP_SSL_PINNING` | `props.android.sslPinning` | — |
+| `CLEVERTAP_HANDSHAKE_DOMAIN` | `props.handshakeDomain` | — |
+| `CLEVERTAP_DISABLE_APP_LAUNCHED` | `"1"` or `"0"` based on `props.disableAppLaunchedEvent` | — |
+| `CLEVERTAP_PROVIDER_1` | HMS manifest entry string if `enableHmsPush` | — |
+| `CLEVERTAP_ENCRYPTION_IN_TRANSIT` | `"1"` if `props.encryptionInTransit` | — |
+
+### Services
+
+When `enablePush = true`:
+- Adds `com.clevertap.android.sdk.pushnotification.fcm.FcmMessageListenerService` (exported: true, MESSAGING_EVENT intent filter)
+- Adds `com.clevertap.android.sdk.pushnotification.CTNotificationIntentService` (exported: false, PUSH_EVENT intent filter)
+
+Both services are **removed** when `enablePush = false`.
+
+### Adding a New Metadata Entry
+
+Add to `METADATA_CONFIGS` array in `withCleverTapAndroidManifest.ts`:
+
+```typescript
+{
+    key: 'CLEVERTAP_MY_FEATURE',
+    getValue: (props) => props.android?.features?.enableMyFeature ? "1" : undefined
+}
+```
+
+---
+
+## 2. Android Resources (strings.xml)
+
+File: `src/android_config/res/withCleverTapAndroidResources.ts`  
+API: `withStringsXml`
+
+Writes string values that the native Kotlin module reads at runtime:
+
+| String Key | Source | Default |
+|------------|--------|---------|
+| `expo_clevertap_register_activity_lifecycle_callbacks` | `props.android.registerActivityLifecycleCallbacks` | `"true"` |
+| `expo_clevertap_enable_push_templates` | `props.android.features.enablePushTemplates` | `"false"` |
+| `expo_clevertap_log_level` | `props.logLevel` | `"-1"` |
+
+The Kotlin module (`CleverTapReactApplicationLifecycleListener`) reads these from generated `R.string` resources at runtime.
+
+**To add a new runtime-configurable value:**
+1. Add the string to `STRING_KEYS` map
+2. Add a `DEFAULT_VALUES` entry
+3. Add `addOrUpdateString()` call reading from props
+4. Read it in `CleverTapReactApplicationLifecycleListener.kt`
+
+---
+
+## 3. Gradle Properties System
+
+Files:
+- `src/android_config/utility/constants.ts` — key names + default versions
+- `src/android_config/utility/utils.ts` — property creation helpers
+- `src/android_config/gradle/withClevertapAndroidAppBuildGradle.ts` — writes to `gradle.properties`
+
+### Feature Flags Written to `gradle.properties`
+
+```
+clevertapCoreEnabled=true           # always true
+clevertapPushEnabled=false
+clevertapPushTemplatesEnabled=false
+clevertapInAppEnabled=false
+clevertapInboxEnabled=false
+clevertapMediaForInAppsInboxEnabled=false
+clevertapInstallReferrerEnabled=false
+clevertapHmsPushEnabled=false
+clevertapGoogleAdIdEnabled=false
+clevertapPlayReviewEnabled=false
+```
+
+### Default Dependency Versions Written to `gradle.properties`
+
+```
+clevertapCoreSdkVersion=7.5.2
+androidxCoreVersion=1.13.0
+firebaseMessagingVersion=24.0.0
+clevertapPushTemplatesSdkVersion=2.1.0
+appCompatVersion=1.7.0
+fragmentVersion=1.5.4
+recyclerViewVersion=1.3.2
+viewPagerVersion=1.0.0
+materialVersion=1.12.0
+glideVersion=4.12.0
+media3Version=1.4.0
+installReferrerVersion=2.2
+clevertapHmsSdkVersion=1.5.0
+hmsPushVersion=6.11.0.300
+playServicesAdsVersion=18.2.0
+playReviewVersion=2.0.2
+```
+
+**Update behavior**: new properties are appended; existing ones are updated if value differs.
+
+### Dependency Template (app/build.gradle)
+
+File: `src/android_config/utility/androidAppDepsTemplate.ts`
+
+Uses `mergeContents` with tag `clevertap-sdk-dependencies` to inject conditionally into the `dependencies {}` block.
+
+Each feature group is a separate function returning a Groovy snippet:
+
+```typescript
+const generateCoreDependencies = () => `
+    // Core features
+    implementation("com.clevertap.android:clevertap-android-sdk:${getVersionProperty(KEYS.CLEVERTAP_SDK_VERSION)}")
+    implementation("androidx.core:core:${getVersionProperty(KEYS.ANDROIDX_CORE_VERSION)}")`;
+```
+
+The template uses `project.findProperty('key') ?: 'defaultVersion'` — so gradle.properties controls versions, with fallback to hardcoded defaults.
+
+---
+
+## 4. Root Gradle (settings.gradle + root build.gradle)
+
+File: `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts`
+
+**Current hardcoded classpath versions:**
+
+| Classpath | Version |
+|-----------|---------|
+| `com.google.gms:google-services` | `4.4.2` |
+| `com.huawei.agconnect:agcp` | `1.9.1.301` |
+| `com.android.tools.build:gradle` | `8.6.0` |
+
+- `withCleverTapSettingsGradle` — adds Huawei Maven repo inside first `repositories {}` block
+- `withCleverTapRootGradle` — adds/updates classpaths; adds HMS Maven repo to **all** `repositories {}` blocks (using tagged marker `@clevertap-hms-repositories-begin/end` for idempotency)
+
+Google Services classpath is only added when `enablePush = true`.  
+HMS + AGP classpaths are only added when `enableHmsPush = true`.
+
+---
+
+## 5. File Copy Operations
+
+File: `src/android_config/io/withCleverTapAndroidCopyFiles.ts`  
+API: `withDangerousMod` (platform: `'android'`)
+
+### HMS Config
+
+Source: `{projectRoot}/assets/agconnect-services.json`  
+Dest: `{projectRoot}/android/app/agconnect-services.json`  
+Condition: `enableHmsPush = true`
+
+### Custom Notification Sounds
+
+Source: `{projectRoot}/assets/{soundFileName}`  
+Dest: `{projectRoot}/android/app/src/main/res/raw/{soundFileName}`
+
+- Accepts `string` or `string[]` in `props.android.customNotificationSound`
+- Tracks copied files in `clevertap_copied_sounds.txt` marker file
+- **Cleans up** sounds removed from config (removed from marker file)
+- Skips re-copy if file sizes match and destination is newer
+
+---
+
+## 6. Complete Feature Checklist (for adding a new Android feature)
+
+- [ ] `types/androidTypes.ts` — add to `Features` (and `Dependencies` if versioned)
+- [ ] `src/android_config/utility/constants.ts` — add key to `CLEVERTAP_GRADLE_PROPERTIES_KEYS` + version to `CLEVERTAP_DEPENDENCIES_DEFAULT_VERSIONS`
+- [ ] `src/android_config/utility/utils.ts` `createFeatureProperties()` — add `createGradleProperty(KEYS.MY_KEY, ...)`
+- [ ] `src/android_config/utility/androidAppDepsTemplate.ts` — add `generateMyFeatureDependencies()` and include in `generateDependenciesTemplate()`
+- [ ] `src/android_config/gradle/withClevertapAndroidAppBuildGradle.ts` — add to destructured features
+- [ ] `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts` — add to destructured features in both plugin + sub-functions if classpath/repo needed
+- [ ] `src/android_config/manifest/withCleverTapAndroidManifest.ts` — add MetadataConfig if manifest entry needed
+- [ ] `src/android_config/res/withCleverTapAndroidResources.ts` — add string if value needs runtime access by Kotlin
+- [ ] `android/src/main/.../CleverTapReactApplicationLifecycleListener.kt` — read new string if added above
+- [ ] `CTExample/app.json` — add feature to plugin config

--- a/.claude/skills/clevertap-expo-plugin-dev/config-reference.md
+++ b/.claude/skills/clevertap-expo-plugin-dev/config-reference.md
@@ -1,0 +1,180 @@
+# Config Reference — CleverTap Expo Plugin
+
+## Full `CleverTapPluginProps` Schema
+
+```typescript
+type CleverTapPluginProps = {
+  // REQUIRED
+  accountId: string;          // CleverTap Project ID
+  accountToken: string;       // CleverTap Project Token
+  android: Android;           // Android config (always required)
+
+  // OPTIONAL — cross-platform
+  accountRegion?: string;     // e.g. "in1", "us1"
+  proxyDomain?: string;       // Custom analytics proxy domain
+  spikyProxyDomain?: string;  // Custom proxy for push impression events
+  logLevel?: number;          // CleverTap log level (-1 = off, 0 = info, 2 = debug)
+  disableAppLaunchedEvent?: boolean;  // Disable App Launched event
+  handshakeDomain?: string;   // Custom handshake domain
+  encryptionLevel?: CleverTapEncryptionLevel;  // 0 = None, 1 = Medium
+  encryptionInTransit?: boolean;  // Encrypt all event data in transit
+  customIdentifiers?: string; // Comma-separated: "Email,Phone"
+
+  // OPTIONAL — platform-specific
+  ios?: iOS;
+}
+
+enum CleverTapEncryptionLevel {
+  None = 0,
+  Medium = 1,
+}
+```
+
+## Android Type
+
+```typescript
+interface Android {
+  features: Features;                          // All feature flags (required)
+  customNotificationSound?: string | string[]; // Sound file(s) from assets/
+  backgroundSync?: string;                     // "0" or "1"
+  defaultNotificationChannelId?: string;       // Default channel ID
+  inAppExcludeActivities?: string;             // Comma-separated activity names
+  sslPinning?: string;                         // "0" or "1"
+  registerActivityLifecycleCallbacks?: boolean; // Default: true (via Kotlin module)
+}
+
+interface Features {
+  enablePush?: boolean;                   // FCM push + Firebase classpath
+  enablePushTemplates?: boolean;          // Push Templates SDK
+  enableInApp?: boolean;                  // InApp dependency (appcompat, fragment)
+  enableInbox?: boolean;                  // AppInbox dependencies
+  enableMediaForInAppsInbox?: boolean;    // media3 ExoPlayer
+  enableInstallReferrer?: boolean;        // Install Referrer SDK
+  enableHmsPush?: boolean;               // HMS Push (Huawei)
+  enableGoogleAdId?: boolean;            // Google Ad ID (AD_ID permission)
+  enablePlayReview?: boolean;            // Google Play In-App Review (SDK 7.4.0+)
+}
+```
+
+## iOS Type
+
+```typescript
+type iOS = {
+  mode: string;                           // "development" | "production" — REQUIRED for iOS
+  deviceFamily?: string;                  // "1" iPhone, "2" iPad, "1,2" both
+  disableIDFV?: boolean;
+  enableFileProtection?: boolean;
+  enableURLDelegateChannels?: [number];
+  notifications?: NotificationFeature;
+}
+
+type NotificationFeature = {
+  notificationCategories?: [NotificationCategory];
+  enablePushInForeground?: boolean;
+  enableRichMedia?: boolean;     // Adds NSE target
+  enablePushImpression?: boolean; // Also adds NSE target
+  enablePushTemplate?: boolean;  // Adds NCE target
+  iosNSEFilePath?: string;       // Custom NSE Swift file path
+  iosNCEFilePath?: string;       // Custom NCE Swift file path
+  iosPushAppGroup?: string;      // App group: "group.com.myapp.clevertap"
+}
+```
+
+---
+
+## Example `app.json` Plugin Config
+
+```json
+{
+  "plugins": [
+    [
+      "@clevertap/clevertap-expo-plugin",
+      {
+        "accountId": "YOUR_ACCOUNT_ID",
+        "accountToken": "YOUR_ACCOUNT_TOKEN",
+        "accountRegion": "in1",
+        "logLevel": 2,
+        "encryptionLevel": 1,
+        "encryptionInTransit": true,
+        "customIdentifiers": "Email,Phone",
+        "proxyDomain": "analytics.example.com",
+        "android": {
+          "features": {
+            "enablePush": true,
+            "enablePushTemplates": true,
+            "enableInApp": true,
+            "enableInbox": true,
+            "enableMediaForInAppsInbox": true,
+            "enableInstallReferrer": true,
+            "enableGoogleAdId": true,
+            "enablePlayReview": true
+          },
+          "customNotificationSound": ["notification.mp3", "alert.mp3"],
+          "defaultNotificationChannelId": "default_channel",
+          "registerActivityLifecycleCallbacks": true
+        },
+        "ios": {
+          "mode": "development",
+          "deviceFamily": "1,2",
+          "disableIDFV": false,
+          "enableFileProtection": true,
+          "notifications": {
+            "enableRichMedia": true,
+            "enablePushImpression": true,
+            "enablePushTemplate": true,
+            "enablePushInForeground": true,
+            "iosPushAppGroup": "group.com.example.clevertap"
+          }
+        }
+      }
+    ]
+  ]
+}
+```
+
+---
+
+## How to Add a New Config Option
+
+### Root-level (cross-platform)
+
+1. Add to `CleverTapPluginProps` in `types/types.ts`
+2. Android manifest: add to `METADATA_CONFIGS` in `src/android_config/manifest/withCleverTapAndroidManifest.ts`
+3. iOS plist: add to `withCleverTapInfoPlist.ts`
+4. If it affects runtime behavior read by Kotlin: add to `withCleverTapAndroidResources.ts` + native Kotlin
+
+### Android-only feature flag
+
+See `android-reference.md` → section 6 (Complete Feature Checklist)
+
+### iOS-only option
+
+1. Add to `iOS` or `NotificationFeature` in `types/iOSTypes.ts`
+2. Conditionally apply in `src/withClevertapIos.ts`
+3. Implement modifier in appropriate `src/iOS_config/` file
+
+---
+
+## Current Default Dependency Versions (as of v0.0.4)
+
+| Dependency | Version |
+|------------|---------|
+| CleverTap Android SDK | `7.5.2` |
+| androidx.core | `1.13.0` |
+| firebase-messaging | `24.0.0` |
+| push-templates | `2.1.0` |
+| appcompat | `1.7.0` |
+| fragment | `1.5.4` |
+| recyclerview | `1.3.2` |
+| viewpager | `1.0.0` |
+| material | `1.12.0` |
+| glide | `4.12.0` |
+| media3 | `1.4.0` |
+| installreferrer | `2.2` |
+| clevertap-hms-sdk | `1.5.0` |
+| HMS push | `6.11.0.300` |
+| play-services-ads-identifier | `18.2.0` |
+| play review | `2.0.2` |
+| Google Services classpath | `4.4.2` |
+| HMS classpath (agcp) | `1.9.1.301` |
+| AGP classpath | `8.6.0` |

--- a/.claude/skills/clevertap-expo-plugin-dev/ios-reference.md
+++ b/.claude/skills/clevertap-expo-plugin-dev/ios-reference.md
@@ -1,0 +1,191 @@
+# iOS Reference — CleverTap Expo Plugin
+
+## iOS Orchestrator Chain
+
+File: `src/withClevertapIos.ts`
+
+```
+withCleverTapIos(config, props)
+├── withAppEnvironment           → .entitlements: aps-environment (development/production)
+├── withRemoteNotificationsPermissions → Info.plist: UIBackgroundModes += remote-notification
+├── withCleverTapEntitlements    → .entitlements: com.apple.security.application-groups (if iosPushAppGroup)
+├── [if enablePushTemplate]
+│   ├── withCleverTapNCE         → copy NCE Swift/plist files via withDangerousMod
+│   └── withCleverTapXcodeProjectNCE → add NCE Xcode target
+├── [if enableRichMedia || enablePushImpression]
+│   ├── withCleverTapNSE         → copy NSE Swift/plist files via withDangerousMod
+│   ├── withCleverTapXcodeProjectNSE → add NSE Xcode target
+│   └── withAppGroupPermissionsNSE → NSE entitlements: app group
+├── withCleverTapPod             → Podfile: add clevertap-react-native pod + extension pods
+├── withCleverTapInfoPlist       → Info.plist: credentials, IDFV, file protection, URL delegate
+└── withCleverTapBridgingHeader  → Adds ObjC bridging header for Swift interop
+```
+
+---
+
+## 1. Info.plist
+
+File: `src/iOS_config/withCleverTapInfoPlist.ts`  
+API: `withInfoPlist`
+
+Sets CleverTap configuration keys directly in Info.plist. These are read by the CleverTap iOS SDK at app launch.
+
+| Plist Key | Source | Notes |
+|-----------|--------|-------|
+| `CleverTapAccountID` | `props.accountId` | Required |
+| `CleverTapToken` | `props.accountToken` | Required |
+| `CleverTapRegion` | `props.accountRegion` | Optional |
+| `CleverTapProxyDomain` | `props.proxyDomain` | Optional |
+| `CleverTapSpikyProxyDomain` | `props.spikyProxyDomain` | Optional |
+| `CleverTapHandshakeDomain` | `props.handshakeDomain` | Optional |
+| `CleverTapDisableIDFV` | `props.ios.disableIDFV` | Optional boolean |
+| `CleverTapEnableFileProtection` | `props.ios.enableFileProtection` | Optional boolean |
+| `CleverTapURLDelegateChannels` | `props.ios.enableURLDelegateChannels` | Optional `[number]` |
+| `CleverTapLogLevel` | `props.logLevel` | Optional number |
+| `CleverTapEncryptionLevel` | `props.encryptionLevel` | Optional 0/1 |
+| `CleverTapEncryptionInTransit` | `props.encryptionInTransit` | Optional boolean |
+| `CleverTapDisableAppLaunchedEvent` | `props.disableAppLaunchedEvent` | Optional boolean |
+
+### UIBackgroundModes
+
+`withRemoteNotificationsPermissions` ensures `remote-notification` is present in `UIBackgroundModes`. This is always applied (not conditional).
+
+---
+
+## 2. Entitlements
+
+### APS Environment (always applied)
+
+```typescript
+newConfig.modResults["aps-environment"] = clevertapProps.ios?.mode; // "development" | "production"
+```
+
+`mode` is **required** — throws if missing.
+
+### App Groups (conditional on `iosPushAppGroup`)
+
+```typescript
+config.modResults['com.apple.security.application-groups'] = [props.ios.notifications.iosPushAppGroup];
+```
+
+---
+
+## 3. Notification Service Extension (NSE)
+
+File: `src/iOS_config/withCleverTapNotificationServiceExtension.ts`
+
+Condition: `enableRichMedia = true` OR `enablePushImpression = true`
+
+### `withCleverTapNSE` (file copy, `withDangerousMod`)
+
+- Reads default NSE Swift from `support/serviceExtensionFiles/` OR user-provided `iosNSEFilePath`
+- Writes Swift file to `ios/CleverTapNotificationServiceExtension/NotificationService.swift`
+- Writes `Info.plist` for the NSE target
+- Updates bundle versions via `NSUpdaterManager`
+
+### `withCleverTapXcodeProjectNSE` (Xcode target, `withXcodeProject`)
+
+- Adds a new Xcode target of type `app_extension`
+- Adds build phases: Compile Sources, Frameworks, Resources
+- Sets `DEVELOPMENT_TEAM`, `IPHONEOS_DEPLOYMENT_TARGET`, `TARGETED_DEVICE_FAMILY`
+- Links to the main target's embed frameworks
+
+### `withAppGroupPermissionsNSE` (NSE entitlements)
+
+- Adds `com.apple.security.application-groups` to the NSE target's entitlements
+- Condition: `iosPushAppGroup` is set
+
+---
+
+## 4. Notification Content Extension (NCE)
+
+File: `src/iOS_config/withCleverTapNotificationContentExtension.ts`
+
+Condition: `enablePushTemplate = true`
+
+### `withCleverTapNCE` (file copy, `withDangerousMod`)
+
+- Writes NCE Swift file to `ios/CleverTapNotificationContentExtension/`
+- Writes NCE `Info.plist`
+
+### `withCleverTapXcodeProjectNCE` (Xcode target, `withXcodeProject`)
+
+- Adds NCE target with build phases and settings (similar to NSE)
+
+---
+
+## 5. Podfile
+
+File: `src/iOS_config/withCleverTapPodfile.ts`  
+API: `withDangerousMod` (platform: `'ios'`)
+
+Uses `mergeContents` with tagged blocks for idempotency.
+
+- Always adds `clevertap-react-native` pod for main target
+- If NSE enabled: adds `CleverTap-iOS-SDK` pod for `CleverTapNotificationServiceExtension` target
+- If NCE enabled: adds `CTNotificationContent` pod for `CleverTapNotificationContentExtension` target
+- References Podfile snippets from `src/iOS_config/IOSConstants.ts`
+
+---
+
+## 6. Bridging Header
+
+File: `src/iOS_config/withCleverTapBridgingHeader.ts`
+
+Adds an ObjC-Swift bridging header to the main app target, importing:
+- `CleverTap.h`
+- `CleverTapReactManager.h`
+
+---
+
+## 7. iOS Constants
+
+File: `src/iOS_config/IOSConstants.ts`
+
+Centralizes:
+- Target names: `NSE_TARGET_NAME = "CleverTapNotificationServiceExtension"`, `NCE_TARGET_NAME = "CleverTapNotificationContentExtension"`
+- File names for NSE/NCE Swift and plist files
+- Podfile snippet strings
+- Regex patterns used for Podfile `mergeContents` anchors
+
+**If you add a new iOS extension target, define its constants here.**
+
+---
+
+## 8. iOS Support Utilities
+
+| File | Purpose |
+|------|---------|
+| `src/iOS_config/FileManager.ts` | Async `readFile`, `writeFile`, `copyFile` using `fs.promises` |
+| `src/iOS_config/NSUpdaterManager.ts` | Updates `CFBundleVersion` and `CFBundleShortVersionString` in extension plists to match main app |
+
+---
+
+## 9. Adding a New iOS Feature
+
+Example: adding an optional `enableSomeFeature` to `iOS` type.
+
+1. **`types/iOSTypes.ts`** — add field to `iOS` or `NotificationFeature`
+2. **`src/withClevertapIos.ts`** — add conditional modifier call
+3. **`src/iOS_config/withCleverTapInfoPlist.ts`** — if it writes to Info.plist
+4. **`src/iOS_config/IOSConstants.ts`** — if it needs new target names / file paths
+5. **`src/iOS_config/withCleverTapPodfile.ts`** — if it needs new pods
+
+---
+
+## 10. iOS Config Summary Table
+
+| iOS Feature | `iOSTypes.ts` Field | Applied By |
+|-------------|--------------------|-----------:|
+| APNs environment | `ios.mode` | `withAppEnvironment` |
+| App group | `ios.notifications.iosPushAppGroup` | `withCleverTapEntitlements` + `withAppGroupPermissionsNSE` |
+| Foreground push | `notifications.enablePushInForeground` | `withCleverTapInfoPlist` |
+| Rich push / NSE | `notifications.enableRichMedia` | `withCleverTapNSE` + `withCleverTapXcodeProjectNSE` |
+| Push impressions | `notifications.enablePushImpression` | (same as NSE, triggers NSE target) |
+| Push templates / NCE | `notifications.enablePushTemplate` | `withCleverTapNCE` + `withCleverTapXcodeProjectNCE` |
+| Custom NSE file | `notifications.iosNSEFilePath` | `withCleverTapNSE` (file source) |
+| Custom NCE file | `notifications.iosNCEFilePath` | `withCleverTapNCE` (file source) |
+| Disable IDFV | `ios.disableIDFV` | `withCleverTapInfoPlist` |
+| File protection | `ios.enableFileProtection` | `withCleverTapInfoPlist` |
+| URL delegate | `ios.enableURLDelegateChannels` | `withCleverTapInfoPlist` |
+| Device family | `ios.deviceFamily` | NSE/NCE Xcode targets (`TARGETED_DEVICE_FAMILY`) |

--- a/.claude/skills/ctexample-testing/SKILL.md
+++ b/.claude/skills/ctexample-testing/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ctexample-testing
+description: Runs end-to-end tests on the CTExample app using Maestro and ADB against a running Android emulator. Verifies CleverTap SDK initialization, event recording, and log output after plugin changes. Use when the user asks to test the example app, verify plugin changes on device, or check CleverTap SDK behavior on the emulator.
+---
+
+# CTExample App — Testing Guide
+
+## Additional Resources
+
+- [App UI Reference](app-reference.md) — Accordion menu sections, Maestro text targets, form element placeholders, and logcat verification patterns
+- [CleverTap Expo Plugin Dev Skill](../clevertap-expo-plugin-dev/SKILL.md) — Plugin architecture and development patterns
+
+---
+
+## I. App Identity
+
+| Property | Value |
+|----------|-------|
+| Package | `com.clevertap.expo.demo` |
+| Main Activity | `.MainActivity` |
+| Debug Level | `3` (verbose — set in `CTExample/App.js` constructor) |
+| Plugin Dependency | `"@clevertap/clevertap-expo-plugin": "file:.yalc/@clevertap/clevertap-expo-plugin"` |
+| Autolinking | `"nativeModulesDir": ".."` (resolves native module from plugin root) |
+
+---
+
+## II. Setup Workflow
+
+Before running any test, the plugin must be built, published via yalc, and the app must be running on an emulator with Metro connected.
+
+### 1. Build and publish the plugin
+
+```bash
+npm run build
+yalc publish
+```
+
+### 2. Link to CTExample
+
+```bash
+cd CTExample
+yalc add @clevertap/clevertap-expo-plugin
+npm install
+```
+
+### 3. Prebuild and run
+
+```bash
+npx expo prebuild --clean --platform android
+npx expo run:android
+```
+
+### 4. Verify prebuild output
+
+Inspect the generated `android/` directory:
+
+| File | What to Check |
+|------|--------------|
+| `gradle.properties` | Version properties match `constants.ts` |
+| `app/build.gradle` | Dependency versions and feature flags |
+| `app/src/main/AndroidManifest.xml` | Metadata entries (account ID, token, region) |
+| `build.gradle` (root) | Classpaths (Google Services, HMS if enabled) |
+
+### 5. Push subsequent changes
+
+After further plugin edits, push without re-adding:
+
+```bash
+# From plugin root
+npm run build && yalc push
+# CTExample picks up changes automatically via .yalc link
+```
+
+---
+
+## III. Running Tests with Maestro
+
+Maestro is used for UI automation. Write flows as YAML, execute with `maestro test`.
+
+### General Pattern
+
+```bash
+# 1. Clear logcat
+adb logcat -c
+
+# 2. Run Maestro flow
+~/.maestro/bin/maestro test /tmp/test-flow.yaml
+
+# 3. Verify via logcat
+adb logcat -d | grep -i "CleverTap" | grep -iE "PATTERN"
+
+# 4. Capture screenshot (optional)
+adb shell screencap -p /sdcard/screen.png && adb pull /sdcard/screen.png /tmp/screen.png
+```
+
+### Restarting the App
+
+If the app is on the wrong screen or showing an error overlay, force restart:
+
+```bash
+adb shell am force-stop com.clevertap.expo.demo
+adb shell am start -n com.clevertap.expo.demo/.MainActivity
+```
+
+**Do NOT use Maestro's `launchApp` without Metro running** — it cold-starts the app, which crashes if the JS bundle can't be loaded.
+
+---
+
+## IV. Test: Record Event
+
+### Maestro Flow
+
+```yaml
+appId: com.clevertap.expo.demo
+---
+- launchApp
+- waitForAnimationToEnd
+- tapOn: "Record Event"
+- waitForAnimationToEnd
+- tapOn: "Enter event name"
+- inputText: "TestEvent"
+- tapOn: "Record event"
+```
+
+### Verification
+
+```bash
+adb logcat -d | grep -i "CleverTap" | grep -iE "Pushing event onto queue|Processing batch|Send queue contains"
+```
+
+**Expected output:**
+
+```
+CleverTap:ACCT_ID: Pushing event onto queue flush sync
+CleverTap:ACCT_ID: Processing batch of N events
+CleverTap:ACCT_ID: Send queue contains N items: [{...}]
+```
+
+The `Send queue contains` line includes the full JSON payload. Look for:
+- `"evtName":"TestEvent"` — confirms the event was recorded
+- `"SDK Version":NNNNN` — confirms SDK version (e.g. `80000` = v8.0.0)
+- `"type":"event"` — confirms it's an event (not profile/ping)
+
+**Send failure is expected** with test credentials — the SDK queues and attempts to send, but the server rejects the test account. The event reaching the queue confirms the SDK is working.
+
+---
+
+## V. Logcat Verification Patterns
+
+| What to Verify | Grep Pattern | Success Indicator |
+|---------------|-------------|-------------------|
+| SDK initialized | `CleverTapProfileDidInitialize` | Log contains a CleverTap ID |
+| Event queued | `Pushing event onto queue` | Appears after recording an event |
+| Batch sent | `Processing batch of` | Shows count of events in batch |
+| Queue payload | `Send queue contains` | Full JSON with event names, SDK version |
+| FCM token registered | `action.*register.*fcm` | Token string present |
+| Inbox ready | `CleverTapInboxDidInitialize` | Appears on app launch |
+| SDK version | `SDK Version` | Numeric: `80000` = v8.0.0, `75200` = v7.5.2 |
+
+---
+
+## VI. Troubleshooting
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| "Unable to load script" on app launch | Metro bundler not running | `cd CTExample && npx react-native start --port 8081`, then force restart app |
+| Maestro "Element not found" | App on wrong screen (home, error overlay, splash) | Force restart: `adb shell am force-stop com.clevertap.expo.demo && adb shell am start -n com.clevertap.expo.demo/.MainActivity` |
+| Maestro can't tap RN error overlay buttons | Error overlay uses custom rendering invisible to accessibility | Force restart the app instead of trying to tap RELOAD |
+| Events queued but send fails | Test account credentials rejected by server | **Expected behavior** — SDK is working correctly |
+| `processDebugGoogleServices` build failure | Empty or invalid `google-services.json` | Add valid Firebase config to `CTExample/assets/google-services.json` |
+| Metro running but app still crashes | Metro started from wrong directory | Must run from `CTExample/`, not plugin root |

--- a/.claude/skills/ctexample-testing/app-reference.md
+++ b/.claude/skills/ctexample-testing/app-reference.md
@@ -1,0 +1,119 @@
+# CTExample App — UI & Maestro Reference
+
+This file maps the CTExample app's UI elements to their **exact Maestro text targets**, form placeholders, and the CleverTap API each section exercises. Use this when writing new Maestro flows.
+
+---
+
+## 1. Accordion Sections
+
+The app uses an `ExpandableListView` component. Each section header is a red bar with white text. Tapping expands/collapses it.
+
+| Section Header | Maestro Target | CleverTap API |
+|---------------|---------------|---------------|
+| Record Event | `"Record Event"` | `CleverTap.recordEvent(name, props)` |
+| Update User | `"Update User"` | `CleverTap.profileSet(profile)` |
+| User Properties | `"User Properties"` | `profileSetMultiValues`, `profileAddMultiValue`, `profileIncrementValue` |
+| Identity Management | `"Identity Management"` | `CleverTap.onUserLogin(profile)`, `CleverTap.getCleverTapID()` |
+| Location | `"Location"` | `CleverTap.setLocation(lat, lng)`, `CleverTap.profileSet({Locale})` |
+| Events | `"Events"` | `CleverTap.recordEvent()`, `CleverTap.recordChargedEvent()` |
+| Product Experiences: Vars | `"Product Experiences: Vars"` | `CleverTap.defineVariables()`, `CleverTap.syncVariables()`, `CleverTap.fetchVariables()` |
+| Push Notifications | `"Push Notifications"` | `CleverTap.createNotificationChannel()`, `CleverTap.createNotification()` |
+| App Inbox | `"App Inbox"` | `CleverTap.initializeInbox()`, `CleverTap.showInbox()` |
+| Push Templates | `"Push Templates"` | Push template rendering |
+| Push Primer Local InApp | `"Push Primer Local InApp"` | `CleverTap.promptPushPrimer()`, `CleverTap.promptForPushPermission()` |
+| InApp Controls | `"InApp Controls"` | `CleverTap.suspendInAppNotifications()`, `CleverTap.resumeInAppNotifications()` |
+
+---
+
+## 2. Form Elements
+
+### Record Event Form
+
+| Element | Maestro Target | Purpose |
+|---------|---------------|---------|
+| Name input | `"Enter event name"` | Event name passed to `recordEvent()` |
+| Add param button | `"Add param"` | Adds key-value pair fields |
+| Param key input | `"Param key"` | Key for event property |
+| Param value input | `"Param value"` | Value for event property |
+| Submit button | `"Record event"` | Calls `CleverTap.recordEvent(name, props)` |
+
+### Update User Form
+
+| Element | Maestro Target | Purpose |
+|---------|---------------|---------|
+| Name input | `"Enter profile name"` | Profile property name |
+| Add param button | `"Add param"` | Adds key-value pair fields |
+| Submit button | `"Update user"` | Calls `CleverTap.profileSet()` |
+
+---
+
+## 3. Source Files
+
+| File | Purpose |
+|------|---------|
+| `CTExample/App.js` | Main component — accordion data, form configs, CleverTap listeners, event handlers |
+| `CTExample/app-utils.js` | Helper functions — `recordEvent()`, `pushEvent()`, `chargedEvent()`, listener setup |
+| `CTExample/constants.js` | Action constants — all action type strings (e.g. `RECORD_EVENT`, `PUSH_EVENT`) |
+| `CTExample/DynamicForm.js` | Reusable form component — renders name input + dynamic key-value params |
+| `CTExample/ExpandableListView.js` | Accordion UI component — expandable sections with action buttons |
+| `CTExample/app.json` | Plugin configuration — account ID, token, region, features, notification settings |
+
+---
+
+## 4. App Configuration (app.json)
+
+The plugin config in `CTExample/app.json` under `plugins` → `@clevertap/clevertap-expo-plugin`:
+
+| Config Key | Test Value | Notes |
+|-----------|-----------|-------|
+| `accountId` | `"TEST-46W-WWR-R85Z"` | Test account — server rejects requests |
+| `accountToken` | Test token | Paired with test account ID |
+| `accountRegion` | `"eu1"` | EU region |
+| `logLevel` | `3` | Verbose logging |
+| `android.features.enablePush` | `true` | FCM push enabled |
+| `android.features.enableHmsPush` | `false` | HMS push disabled |
+
+---
+
+## 5. Maestro Flow Patterns
+
+### Basic: Tap a section and interact
+
+```yaml
+appId: com.clevertap.expo.demo
+---
+- launchApp
+- waitForAnimationToEnd
+- tapOn: "Section Name"
+- waitForAnimationToEnd
+- tapOn: "Input placeholder"
+- inputText: "value"
+- tapOn: "Submit button text"
+```
+
+### With parameters: Record event with key-value props
+
+```yaml
+appId: com.clevertap.expo.demo
+---
+- launchApp
+- waitForAnimationToEnd
+- tapOn: "Record Event"
+- waitForAnimationToEnd
+- tapOn: "Enter event name"
+- inputText: "Purchase"
+- tapOn: "Add param"
+- tapOn: "Param key"
+- inputText: "item"
+- tapOn: "Param value"
+- inputText: "shirt"
+- tapOn: "Record event"
+```
+
+### Scrolling to off-screen sections
+
+```yaml
+- scrollUntilVisible:
+    element: "InApp Controls"
+    direction: DOWN
+```

--- a/.claude/skills/example-and-release/SKILL.md
+++ b/.claude/skills/example-and-release/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: example-and-release
+description: How to finish a CleverTap Expo plugin release sync — update the CTExample app (app.json + package.json), showcase any NEW clevertap-react-native APIs as runnable demo buttons in CTExample, append a row to the README compatibility matrix, write the CHANGELOG entry in the exact existing format, choose the plugin's semver bump, and verify with the compile-only build loop (yalc + expo prebuild + gradle/xcodebuild). Use at the end of a release sync.
+---
+
+# Example app + release finishing steps
+
+The tail of a release sync: keep the example app current, document the change, bump
+the plugin version, and verify it compiles. Match the EXISTING formats exactly —
+downstream tooling and humans expect them.
+
+## 1. CTExample app
+
+`CTExample/` is the example Expo app; it consumes the plugin via **yalc**
+(`"@clevertap/clevertap-expo-plugin": "file:.yalc/@clevertap/clevertap-expo-plugin"`
+plus `"expo": { "autolinking": { "nativeModulesDir": ".." } }`).
+
+- `CTExample/package.json` — bump `clevertap-react-native` to match the target
+  `${RN_VERSION}`, and `expo` / `react-native` to match the target Expo SDK (use the
+  react-native version that ships with that Expo SDK, from `expo-sdk-analysis`).
+- `CTExample/app.json` — if the sync added a new feature flag / config field, reflect
+  it in the plugin config block so the demo keeps exercising it. Don't change the test
+  credentials.
+
+## 1b. Showcase NEW clevertap-react-native APIs in CTExample
+
+The plugin itself surfaces no SDK methods — but the CTExample app is a living showcase,
+so when the target `clevertap-react-native` release adds **new public APIs**, add a
+runnable demo button for each so the example stays current. These are pure JS edits in
+the example app (no plugin/native code).
+
+**Where the new APIs come from:** the `clevertap-react-native` changelog's **"API changes"**
+section (available in `expo-diff.json` → `changelogs.rn`). It lists each new method with
+its exact signature, e.g. `fetchInbox(callback?)`, `pushDisplayUnitElementClickedEventForID(unitID, additionalProperties)`.
+Only surface entries under "API changes" (or clearly-new public methods) — NOT bug fixes
+or internal changes.
+
+**Source-verify before adding (IMPORTANT):** a wrong method name becomes a runtime-broken
+button (the native compile gate will NOT catch it — JS isn't type-checked there). Confirm
+the method actually exists in `clevertap-react-native` at the target version. The
+authoritative sources are (a) the changelog's "API changes" section, which states the exact
+new method + signature for that release, and (b) the RN repo's `src/index.js` / `index.d.ts`
+**at the `${RN_VERSION}` tag** via WebFetch (`https://raw.githubusercontent.com/CleverTap/clevertap-react-native/${RN_VERSION}/src/index.js`).
+Do NOT rely on `CTExample/node_modules/clevertap-react-native` — during the sync it still
+holds the PRE-sync version (the target version is only installed in the later post-sync
+build), so a genuinely-new method won't be there yet. If you can't confirm a method from
+the changelog or the tagged source, do NOT add a demo for it — flag it instead.
+
+**The 3-file demo pattern (match the existing entries exactly):**
+1. `CTExample/constants.js` — add a key to the `Actions` object: `NEW_API_KEY: 'NEW_API_KEY',`.
+2. `CTExample/App.js` —
+   - add `{ action: Actions.NEW_API_KEY, name: '<methodName>' }` to the `subCategory` of the
+     most relevant existing `accordionData` category (e.g. App Inbox, Native Display, Events);
+   - add a `case Actions.NEW_API_KEY:` in the `handleItemAction` switch that calls
+     `CleverTap.<method>(...)` with **realistic sample args**, then `break;`.
+3. `CTExample/app-utils.js` — only for multi-step or feedback-bearing demos: add an
+   `export const <helper> = () => { ... showToast(...) + console.log(...) + CleverTap.<method>(...) }`
+   and call `AppUtils.<helper>()` from the switch (simple fire-and-forget calls can go inline
+   in the switch, like `CleverTap.suspendInAppNotifications()`).
+
+Use `const CleverTap = require('clevertap-react-native')` (already imported in App.js).
+For callback-style APIs, pass a callback that `console.log`s the result, mirroring existing
+cases like `getVariables` / `fetchVariables`. Example for the 4.2.0 additions:
+```js
+// constants.js
+FETCH_INBOX: 'FETCH_INBOX',
+// App.js — App Inbox category subCategory
+{ action: Actions.FETCH_INBOX, name: 'fetchInbox' },
+// App.js — handleItemAction switch
+case Actions.FETCH_INBOX:
+  CleverTap.fetchInbox((err, success) => { console.log('fetchInbox result:', success, err); });
+  break;
+```
+
+Record each demoed API in the `apis_demoed` output field. These edits to
+`constants.js` / `App.js` / `app-utils.js` are real source changes and DO belong in the PR.
+
+## 2. README compatibility matrix
+
+`README.md` has a table:
+
+```
+| CleverTap Expo Plugin version | Expo SDK version | React Native version | CleverTap React Native SDK version |
+```
+
+Append ONE new row for this release: `| <new plugin version> | <Expo SDK> | <react-native> | ${RN_VERSION} |`.
+Also update any "Expo NN+ Migration" notes if the Expo jump introduced a new
+`app.json` migration (e.g. the SDK-55 `notification.icon` → `android.notificationIcon`).
+
+## 3. CHANGELOG.md
+
+New entry at the **TOP**, matching the existing format exactly:
+
+```markdown
+### [Version X.Y.Z](https://github.com/CleverTap/clevertap-expo-plugin/releases/tag/X.Y.Z) (Month DD, YYYY)
+
+#### Added
+- Adds support for Expo SDK [<v>](https://expo.dev/changelog/sdk-<v>) and React Native [<rn>](...)
+- Adds support for CleverTap React Native SDK [${RN_VERSION}](...)
+
+#### Android Platform ####
+  - <integration-step change, if any>
+
+#### iOS Platform ####
+  - <integration-step change, if any>
+```
+
+Use `${RELEASE_DATE}` for the date. Derive version-anchor links from the changelog
+dates in `expo-diff.json` (no need to fetch). Only include `#### Android/iOS Platform`
+subsections if there were integration-step changes on that platform.
+
+## 4. Plugin semver bump (`package.json` `version`)
+
+This is the single canonical version file the PR completeness check looks for. Choose:
+
+- **patch** (1.0.x) — dependency version pins only; no new feature/integration step;
+  no breaking Expo/RN change.
+- **minor** (1.x.0) — a new feature flag, a new `compileOnly` dep, or a new additive
+  integration step; backward compatible. (Most common.)
+- **major** (x.0.0) — a removed feature/step, an Android `minSdk` or iOS
+  deployment-target bump propagated to host apps, an `app.json` field removal that
+  breaks existing configs, or a breaking `@expo/config-plugins` adoption.
+
+The plugin's own version is independent of the native SDK versions it pins.
+
+## 5. Verify — compile-only build loop
+
+CI does this for you (the `build/expo` composite). Locally, to verify the plugin
+compiles after edits:
+
+```bash
+npm run build           # compile the plugin (output to build/)
+yalc publish            # publish to the local yalc store
+cd CTExample
+yalc add @clevertap/clevertap-expo-plugin
+npm install
+npx expo prebuild --clean       # regenerate native projects from app.json + plugin
+cd android && ./gradlew :app:assembleDebug   # Android compile
+cd ../ios && pod install && xcodebuild -workspace CTExample.xcworkspace -scheme CTExample -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build   # iOS compile
+```
+
+CI is **compile-only** (no emulator/simulator boot) to fit the 90-min job timeout —
+it proves the plugin's generated native config compiles. For device-level behavior
+testing (SDK init, event recording) use the `ctexample-testing` skill on an emulator
+locally; that is NOT part of the automated sync gate.
+
+After an iOS-affecting change, delete `CTExample/ios/Podfile.lock` before `pod install`
+so the (transitively-floating) `CleverTap-iOS-SDK` re-resolves.
+
+## Completion checklist
+
+- [ ] `CTExample/package.json` (+ `app.json` if a field was added) updated.
+- [ ] README compatibility matrix has a new row.
+- [ ] `CHANGELOG.md` has a new dated entry at the top, correct format.
+- [ ] `package.json` `version` bumped per semver.
+- [ ] The plugin compiles (the CI build gate, or the loop above).

--- a/.claude/skills/expo-sdk-analysis/SKILL.md
+++ b/.claude/skills/expo-sdk-analysis/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: expo-sdk-analysis
+description: How to analyze a new Expo SDK release for anything that affects the CleverTap Expo config plugin — @expo/config-plugins API changes, app.json/app.config schema changes, and Android compileSdk/minSdk/AGP or iOS deployment-target default shifts. Covers reading both the expo.dev release notes and the GitHub CHANGELOG, and walking intermediate SDK versions on a multi-version jump. Use during a release sync when the Expo SDK version is changing.
+---
+
+# Expo SDK analysis
+
+When the target Expo SDK version differs from what the plugin currently supports,
+analyze the Expo release(s) for changes that touch the plugin. The plugin is built
+ON the Expo config-plugin API and reads `app.json` fields, so Expo-side changes can
+break it even when no CleverTap version moves.
+
+## Sources (read BOTH — they're complementary)
+
+Use WebFetch (allowed for Expo; restricted to the doc hosts). The fact-finder
+(`expo_diff.json` → `changelogs.expo`) gives you the exact URLs and marks the Expo
+changelog as `webfetch_needed` (it does NOT parse Expo's HTML — that's your job):
+
+1. **Release notes** (human-readable, motivations): `https://expo.dev/changelog/sdk-<version>`
+2. **GitHub CHANGELOG** (detailed per-package breaking changes): `https://raw.githubusercontent.com/expo/expo/main/CHANGELOG.md`
+
+**Multi-version jumps:** if upgrading across more than one SDK (e.g. 53 → 56), read
+each intermediate version's notes too — breaking changes accumulate.
+
+## What to look for (scan the WHOLE changelog; section names vary by version)
+
+| What | Why it matters to the plugin |
+|------|------------------------------|
+| `@expo/config-plugins` API changes (new/removed/renamed methods, signature changes) | The plugin calls `withAndroidManifest`, `withStringsXml`, `withAppBuildGradle`, `withGradleProperties`, `withProjectBuildGradle`, `withSettingsGradle`, `withInfoPlist`, `withXcodeProject`, `withDangerousMod`, and `mergeContents`. A breaking change in any of these breaks prebuild. |
+| `app.json` / `app.config` schema changes (fields added / deprecated / removed) | The plugin reads config fields. Precedent: SDK 55 **removed `notification.icon`** → the plugin added `android.notificationIcon`. A removed field that the plugin reads must be migrated. |
+| Android `compileSdkVersion` / `targetSdkVersion` / `minSdkVersion` default bumps | The plugin relies on Expo's `useDefaultAndroidSdkVersions()`. Usually no change needed, but confirm the CleverTap SDK AAR is compatible with the new level. |
+| iOS deployment-target / Xcode version bumps | The NSE/NCE extension targets and `IOSConstants.DEPLOYMENT_TARGET` may need updating. |
+| React Native version bump | Note the new RN version for the README compatibility matrix; may change autolinking / build system. |
+| New Architecture / Legacy Architecture changes | The plugin's native Kotlin module is discovered via Expo autolinking — confirm it still resolves. |
+| `expo-module-scripts` / build-tooling changes | May require bumping the `expo` devDependency (see below). |
+
+Anything unrelated to native build config, manifests, gradle, Xcode, autolinking, or
+`app.json` schema is **likely irrelevant** (Expo Router, Expo UI, individual packages
+like expo-camera, EAS Update, CLI dev tooling, etc.).
+
+## How to act
+
+- **Confirmed mechanical fix** (e.g. a removed `app.json` field the plugin reads → adopt
+  the replacement; a renamed config-plugins method → update the call): apply it, and
+  record an `integration_steps_changed` / `build_propagated` entry.
+- **Breaking change needing redesign** (e.g. a config-plugins API the plugin depends on
+  was removed with no drop-in replacement): do NOT guess a rewrite. Add it to
+  `flagged_for_review` (type `expo_breaking`) describing the break and the affected
+  modifier — a human handles it.
+
+## The `expo` devDependency vs peerDependency
+
+The `expo` version in the plugin's `package.json` is a **devDependency** (local
+build/test only); the plugin declares `"expo": "*"` in `peerDependencies`. Bumping the
+devDep is usually NOT required for a new Expo SDK to work. Bump it only if: a new
+config-plugins API is needed, an existing API has a breaking type change, or you want
+local dev/test to match the target. When unsure, leave it and note it.
+
+## Output
+
+Feed your findings into the sync's `build_propagated`, `integration_steps_changed`, or
+`flagged_for_review`, and into the README compatibility-matrix row's
+`react_native` column (the RN version that ships with the target Expo SDK — read it
+from the Expo release notes).

--- a/.claude/skills/integration-step-analysis/SKILL.md
+++ b/.claude/skills/integration-step-analysis/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: integration-step-analysis
+description: How to detect whether a new CleverTap native SDK release (Android core / push-templates / HMS, or the iOS SDK / notification extensions) ADDED, CHANGED, or REMOVED a native integration step that the Expo config plugin must reflect — a new permission, Maven repo, gradle dependency, manifest entry, pod, entitlement, or app.json field. Self-discovering — it derives the plugin's current integration steps from the plugin's own code, then reconciles against the SDK docs. Use during a release sync after version propagation.
+---
+
+# Integration-step analysis (the judgment ~1%)
+
+Version numbers are mechanical (see `native-version-sync`). The harder question is:
+**did this release change the native SETUP the plugin has to perform?** A new
+permission, a new Maven repo, a new pod, a new manifest entry, a new entitlement.
+This skill is the method for answering that safely. The rule throughout:
+**confirm-or-flag, never guess.** A flagged gap is recoverable in review; a wrongly
+added/removed integration step is a broken build or a silently broken feature.
+
+## Step 1 — Derive the plugin's CURRENT integration steps from its own code
+
+Do NOT work from a hardcoded list (it rots). Build the inventory by reading the
+plugin (use the `clevertap-expo-plugin-dev` skill for the map). Enumerate, per area:
+
+**Android**
+- Manifest metadata + permissions: `src/android_config/manifest/withCleverTapAndroidManifest.ts` (`METADATA_CONFIGS` — each entry's `key`, `getValue`, `onAdd` permissions).
+- `strings.xml` runtime values: `src/android_config/res/withCleverTapAndroidResources.ts`.
+- App `build.gradle` dependencies (per feature): `src/android_config/utility/androidAppDepsTemplate.ts` (the `generate*Dependencies` functions and their Maven coordinates).
+- Root gradle classpaths + Maven repos (incl. the Huawei AGConnect repo): `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts`; settings repos in the same area.
+- File copies (HMS `agconnect-services.json`, custom sounds, notification icon): `src/android_config/io/withCleverTapAndroidCopyFiles.ts`.
+- Native Kotlin lifecycle (init, push templates, notification dismissal): `android/src/main/java/expo/modules/adapters/clevertap/`.
+
+**iOS**
+- Info.plist keys, background modes: `src/iOS_config/withCleverTapInfoPlist.ts`.
+- Podfile pods (main + NSE/NCE extension pods): `src/iOS_config/withCleverTapPodfile.ts` + `IOSConstants.ts`.
+- NSE / NCE Xcode targets, entitlements, app groups, deployment target: `withCleverTapNotificationServiceExtension.ts`, `withCleverTapNotificationContentExtension.ts`, `IOSConstants.ts`.
+
+## Step 2 — Reconcile against authoritative sources (per SDK)
+
+For each SDK in scope (CleverTap Android **core**, **push-templates**, **HMS**, and
+the **iOS** SDK + its notification extensions), read what its setup requires at the
+new version and compare to the inventory. Three authoritative sources (use WebFetch,
+restricted to `raw.githubusercontent.com`, `github.com`, `developer.clevertap.com`,
+`reactnative.dev`, `expo.dev`):
+
+1. The native SDK's **install / integration docs** on GitHub (README, docs/).
+2. The **CleverTap docs site** integration pages (Android, iOS, push, HMS, push-templates).
+3. The **changelogs** already in `expo-diff.json` (RN + Android core/pt/hms) — they
+   often announce "you must now add …".
+
+Also consult `expo-diff.json` `android_dependency_diff.core`: a NEW `compileOnly`
+dependency in core is the clearest machine-detectable integration step.
+
+## Step 3 — Decide per candidate change
+
+- **New step required** (e.g. a new permission, a new Maven repo, a new pod, a new
+  `compileOnly` dep, a new manifest metadata key): add it via the right modifier.
+  Follow `clevertap-expo-plugin-dev` for the exact pattern (MetadataConfig entry,
+  a `generate*Dependencies` function + `constants.ts` key + `types/androidTypes.ts`
+  field for a new dep, a Podfile snippet for a new pod, etc.). Record an
+  `integration_steps_changed` entry with `source_verified: true` and the source.
+- **Step changed** (e.g. a permission renamed, a repo URL changed): update it; record it.
+- **Step removed** (the SDK no longer needs it): remove the modifier/entry
+  (the MetadataConfig pattern is bidirectional — disabling removes it). Record it.
+- **Cannot confirm / ambiguous / needs design judgment**: do NOT change anything.
+  Add it to `flagged_for_review` with what the source claimed and where you looked.
+
+## Step 4 — Source-verify before writing
+
+Before adding a Maven coordinate, permission, repo, pod, or entitlement, confirm it
+exists / is required at the new version:
+- Maven coordinates / SDK requirements → the cached native SDK source the fact-finder
+  downloaded (under `~/.cache/clevertap-sdk-versions/`), read with the **Read / Grep /
+  Glob tools** (NOT Bash — Bash paths outside the working dir are denied).
+- Setup procedure → the SDK/CleverTap docs via WebFetch (advisory; for *whether* a
+  step is needed, never for version numbers).
+
+If you cannot confirm it in an authoritative source, flag it — do not add it.
+
+## Per-SDK reminders (so none is forgotten)
+
+- **core** — most integration steps live here (permissions, metadata, the core deps).
+- **push-templates** — gated behind `enablePushTemplates` (which needs `enablePush`);
+  its compileOnly pin is in `android/build.gradle`.
+- **HMS** — Android-only; brings the AGConnect Maven repo + `agcp` classpath + the
+  `agconnect-services.json` file copy. A new HMS requirement touches all three.
+- **iOS core** — version floats via clevertap-react-native; the plugin's iOS steps are
+  Info.plist keys, the bridging header, and the Podfile main pod.
+- **NSE / NCE** — the iOS notification extensions: their pods, target files,
+  entitlements, app groups, and deployment target. A new extension capability is an
+  integration step here.

--- a/.claude/skills/native-version-sync/SKILL.md
+++ b/.claude/skills/native-version-sync/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: native-version-sync
+description: How to propagate CleverTap native SDK version bumps into the Expo plugin for ALL SDKs (Android core / push-templates / HMS, the AndroidX & third-party deps, and the iOS deployment target) using the expo_diff.py fact-finder. Self-discovering — it reads the plugin's own pins at runtime and matches them to the SDK version catalog by Maven coordinate; it hardcodes no version numbers. Use during a release sync to bump dependency versions safely.
+---
+
+# Native version sync (the mechanical core)
+
+This skill covers **version propagation** — bumping the dependency versions the
+plugin pins when a new `clevertap-react-native` release ships. It is deliberately
+**data-driven**: every version, dependency, and mapping is discovered at run time
+from the plugin's own files and the SDK's version catalog. Do NOT hardcode version
+numbers or a key→catalog mapping table — they rot. Discover them every time.
+
+## The ground truth: expo_diff.py
+
+The deterministic fact-finder (`tools/expo_diff.py` in the tooling repo, passed as
+`${DIFF_TOOL_PATH}`) does the exact, boring work and writes `expo-diff.json`. Run it:
+
+```bash
+python3 ${DIFF_TOOL_PATH} --rn-version <target> --expo-sdk-version <target> --plugin-path .
+```
+
+It produces (read the JSON, do not re-derive):
+
+- `chain` / `meta.resolved` — what the target clevertap-react-native release
+  requires: CleverTap Android core, iOS core, push-templates, HMS versions. **The
+  Android core target is authoritative from the RN release**, not from the catalog.
+- `android_catalog_diff.versions` — every `[versions]` entry that changed between
+  the plugin's current core and the target core (parsed with a real TOML parser).
+- `android_dependency_diff.core` — added/removed/changed `compileOnly` vs
+  `implementation` deps in `clevertap-core/build.gradle` (compileOnly = host must
+  provide → plugin change; implementation = transitive → no change).
+- `ios_diff` — iOS deployment-target / podspec dependency changes.
+- `discovery` — the heart: the plugin's own pins matched to the catalog **by Maven
+  coordinate** (see below): `mapped`, `plugin_only`, `catalog_only`, `classpaths`,
+  `ios_deployment_target`.
+- `meta.warnings` / `meta.discovered_pin_count` — the trust signals (see Reliability).
+
+## Why coordinate matching (and the play-services trap)
+
+The fact-finder matches a plugin pin to a catalog version **by the actual Maven
+coordinate** (`group:artifact`), read from the plugin's own
+`androidAppDepsTemplate.ts`, NOT by fuzzy key name. This is critical:
+
+- The plugin's Google-Ad-ID pin uses the artifact `com.google.android.gms:play-services-ads-identifier`.
+- The SDK catalog's `play_services_ads` key is the DIFFERENT artifact `com.google.android.gms:play-services-ads`.
+
+A name-based match would wrongly equate them and bump to the wrong version. The
+coordinate match correctly leaves it in `plugin_only` (flagged, never auto-synced).
+Trust this: only act on coordinate matches the tool reports as `high` confidence.
+
+## What the plugin pins, and where (discover, don't assume)
+
+Read these to confirm the current state (the fact-finder already parsed them, but
+re-verify each value before you write it):
+
+| What | File | How it's stored |
+|------|------|-----------------|
+| CleverTap core + AndroidX/third-party dep versions | `src/android_config/utility/constants.ts` | `CLEVERTAP_DEPENDENCIES_DEFAULT_VERSIONS` (nested groups of `key: 'version'`) |
+| Push-templates pin (module compileOnly) | `android/build.gradle` | `compileOnly("com.clevertap.android:push-templates:X")` |
+| Google-Services / HMS (AGConnect) classpaths | `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts` | `GOOGLE_SERVICES_CLASSPATH` / `HMS_CLASSPATH` string literals |
+| iOS deployment target | `src/iOS_config/IOSConstants.ts` | `DEPLOYMENT_TARGET = "11.0"` |
+| iOS native SDK versions | (not pinned) | float transitively via clevertap-react-native's podspec — do NOT add a version |
+
+The coordinate→version-key wiring lives in `androidAppDepsTemplate.ts` (each
+`getVersionProperty(KEYS.X)` maps a `KEYS` constant to a version key in
+`constants.ts`). That's why the fact-finder can discover the mapping itself.
+
+## How to apply (auto-apply only HIGH confidence)
+
+1. For each `discovery.mapped` row with `"changed": true` and `"confidence": "high"`:
+   re-verify `plugin_current` against `constants.ts` and `catalog_target` against the
+   fetched catalog, then update the `plugin_key` in `constants.ts`. If push-templates
+   changed, also update the `compileOnly` pin in `android/build.gradle`.
+2. Every `discovery.plugin_only` row, and anything not `high` confidence → do NOT
+   change it; add it to `flagged_for_review`. These are plugin-managed artifacts that
+   differ from the catalog. A flagged item is recoverable; a wrong bump is a broken
+   build or a silently-wrong release.
+3. Classpaths (`discovery.classpaths`): change `GOOGLE_SERVICES_CLASSPATH` /
+   `HMS_CLASSPATH` only on a confirmed consumer-facing change. NEVER touch AGP — it's
+   read dynamically from React Native at prebuild time.
+4. iOS deployment target: only bump `IOSConstants.ts` `DEPLOYMENT_TARGET` (and
+   `ios/ExpoAdapterCleverTap.podspec` `:ios => '...'`) if `ios_diff.deployment_target`
+   shows an increase above the current value. Do NOT pin the iOS SDK version anywhere.
+5. New / removed `compileOnly` deps in `android_dependency_diff.core` are an
+   *integration step* change — hand off to the `integration-step-analysis` skill
+   (they need a generator in `androidAppDepsTemplate.ts` + a key in `constants.ts` +
+   a field in `types/androidTypes.ts`).
+
+## Reliability — the fact-finder is the first source, not the only source
+
+- Treat `expo-diff.json` as ground truth for version NUMBERS only. Confirm each
+  number you write against the plugin file + the fetched catalog (the tool dumps raw
+  fetched files under the cache for inspection).
+- If `meta.warnings` is non-empty, or `meta.discovered_pin_count` looks wrong (it
+  should be ~16), the discovery is suspect — verify by hand or flag, don't bulk-apply.
+- Versions NEVER come from a docs page or changelog prose — only from the fact-finder.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for auto-generated sync PRs from clevertap-wrapper-sync[bot].
+* @piyush-kukadiya @akashvercetti @CTLalit @nishant-clevertap @Sonal-Kachare @deeksha-rgb

--- a/.github/workflows/native-release-sync.yml
+++ b/.github/workflows/native-release-sync.yml
@@ -1,0 +1,64 @@
+name: native-release-sync
+
+# Manually-dispatched entry point for syncing the CleverTap Expo plugin with a
+# new clevertap-react-native release and/or a new Expo SDK version. Thin wrapper:
+# collects the target versions and routes to the reusable workflow in the central
+# tooling repo (clevertap-wrapper-tooling). Claude runs headless there, bumps
+# versions, propagates native-integration-step changes, showcases new RN APIs in
+# CTExample, updates the compat matrix + CHANGELOG, compiles CTExample, opens a PR.
+#
+# Unlike the native bridges, the Expo plugin is a config plugin (surfaces no SDK
+# methods); it is driven by clevertap-react-native + Expo SDK versions, and the
+# required native Android/iOS SDK versions are auto-resolved from the RN release.
+#
+# Required repo secrets:
+#   CLEVERTAP_WRAPPER_SYNC_APP_ID, CLEVERTAP_WRAPPER_SYNC_PRIVATE_KEY,
+#   ANTHROPIC_API_KEY, (optional) SLACK_WEBHOOK_URL
+
+on:
+  workflow_dispatch:
+    inputs:
+      clevertap_rn_version:
+        description: 'Target clevertap-react-native version (e.g. 4.2.0).'
+        type: string
+        default: ''
+      expo_sdk_version:
+        description: 'Target Expo SDK version (e.g. 56).'
+        type: string
+        default: ''
+      release_name:
+        description: 'Optional branch suffix (defaults to today YYYY-MM-DD)'
+        type: string
+        default: ''
+      base_ref:
+        description: 'Branch to sync from / open PR against'
+        type: string
+        default: 'develop'
+      model:
+        description: 'Claude model (alias)'
+        type: choice
+        options: [sonnet, opus, haiku]
+        default: sonnet
+      skip_sync:
+        description: 'Skip Claude Sync + post-sync build (pre-sync build still runs). For debugging the pipeline without Claude cost.'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    uses: CleverTap/clevertap-wrapper-tooling/.github/workflows/sync.yml@v1
+    with:
+      wrapper:              expo
+      clevertap_rn_version: ${{ inputs.clevertap_rn_version }}
+      expo_sdk_version:     ${{ inputs.expo_sdk_version }}
+      release_name:         ${{ inputs.release_name }}
+      base_ref:             ${{ inputs.base_ref }}
+      model:                ${{ inputs.model }}
+      skip_sync:            ${{ inputs.skip_sync }}
+      # Expo SDK 55+/RN 0.83+ need macos-15's newer Xcode/Swift to build expo-modules-core.
+      runs_on:              macos-15
+    secrets:
+      app_id:            ${{ secrets.CLEVERTAP_WRAPPER_SYNC_APP_ID }}
+      app_private_key:   ${{ secrets.CLEVERTAP_WRAPPER_SYNC_PRIVATE_KEY }}
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/WRAPPER_SYNC_HANDOFF.md
+++ b/WRAPPER_SYNC_HANDOFF.md
@@ -1,0 +1,158 @@
+# Wrapper-Sync Automation — CleverTap Expo Plugin (Handoff)
+
+> Status: **validated end-to-end on a fork (2026-06-23).** Owner: @piyush-kukadiya.
+> This doc is the "where is the Expo wrapper-sync right now" reference for a fresh
+> Claude session or a new developer. Built on hub branch `task/expo-wrapper-sync`
+> (pending production cutover — see the last section).
+
+## What this is
+
+A "robot" that keeps `@clevertap/clevertap-expo-plugin` up to date when a new
+`clevertap-react-native` release and/or a new Expo SDK version ships. A maintainer
+clicks **Actions → native-release-sync → Run workflow**, types the target
+`clevertap_rn_version` and `expo_sdk_version`, and a headless Claude run (in the
+central tooling repo) bumps versions, propagates native-integration-step changes,
+showcases any new clevertap-react-native APIs in the example app, updates the
+compatibility matrix + CHANGELOG, compiles CTExample, and opens a PR for review.
+
+The robot does the mechanical ~99%; genuine judgment (~1%) is left as
+`flagged_for_review` notes in the PR for a human to settle at merge.
+
+## Why Expo is different from the other wrappers
+
+The React Native / Flutter / Cordova wrappers are native bridges — their sync
+surfaces new SDK *methods*. **The Expo plugin is a config plugin: it surfaces NO
+methods.** It pins dependency versions and generates native setup (manifest,
+gradle, Podfile, iOS extensions) during `expo prebuild`. So the Expo sync is
+**version + build-config + native-integration-step propagation**, driven by the
+clevertap-react-native + Expo SDK versions (the required native Android/iOS SDK
+versions are auto-resolved from the clevertap-react-native release). iOS native
+SDK versions are intentionally UNPINNED here — they float transitively from
+clevertap-react-native's podspec (only the iOS deployment target is propagated).
+
+New `clevertap-react-native` JS APIs are exposed by that package directly, not by
+the plugin — but the sync *does* add runnable demo buttons for them in CTExample
+(a JS-only showcase), so the example stays current. See "What the robot does."
+
+## The two repos
+
+1. **This repo (`clevertap-expo-plugin`)** holds the thin dispatch workflow
+   (`.github/workflows/native-release-sync.yml`), `CODEOWNERS`, the domain skills
+   under `.claude/skills/`, and the plugin + CTExample that the robot edits.
+2. **`CleverTap/clevertap-wrapper-tooling`** (the hub) holds all the reusable CI
+   machinery: the reusable `sync.yml` conductor, composite actions, the Expo
+   orchestrator prompt (`prompts/sync-orchestrator-expo.md`), the PR-body prompt
+   (`prompts/pr-description-expo.md`), the fact-finder (`tools/expo_diff.py`), and
+   the build composite (`.github/actions/build/expo`).
+
+`uses:` pins `@v1` (a moving tag). Note `uses:` does NOT follow org redirects.
+
+## What the robot does (the sync steps)
+
+Driven by `prompts/sync-orchestrator-expo.md` + the five `.claude/skills`:
+1. Run `expo_diff.py` (ground truth for all version numbers).
+2. Resolve the chain (RN target → required Android core / iOS core / push-templates / HMS).
+3. Apply version bumps (only HIGH-confidence coordinate matches; flag the rest).
+4. Classpaths (only consumer-facing, confirmed; never AGP).
+5. New/removed `compileOnly` deps → dep-template + types + constants.
+6. Integration-step reconciliation (native docs + CleverTap docs + RN changelog).
+7. Expo SDK analysis (config-plugin API changes, app.json schema, compileSdk/deployment shifts).
+8. iOS deployment-target propagation (`IOSConstants.ts` + podspec) if it rose.
+9. Update CTExample (`app.json`, `package.json`).
+9b. **Showcase new clevertap-react-native APIs** as demo buttons in CTExample
+   (`constants.js` + `App.js` [+ `app-utils.js`]) — source-verified against the RN
+   repo at the target tag; recorded in `apis_demoed`.
+10. README compat-matrix row + CHANGELOG entry + plugin semver bump.
+
+## The Expo-specific pieces in the hub
+
+- `tools/expo_diff.py` — deterministic fact-finder. Resolves the RN→native chain,
+  diffs the Android version catalog (tomllib) + dependency blocks, diffs the iOS
+  podspec, **discovers** the plugin's pins by parsing `constants.ts` +
+  `androidAppDepsTemplate.ts` and matching to the catalog **by Maven coordinate**
+  (so `play-services-ads-identifier` is correctly NOT confused with the catalog's
+  `play-services-ads`), and extracts **full changelogs (target + intermediates)**
+  for clevertap-react-native, Android core (+ pt/hms), and **iOS core**. Fails loud
+  on uncertainty; never invents a version.
+- `prompts/sync-orchestrator-expo.md` — single combined sync (both platforms in
+  one pass). Auto-applies only HIGH-confidence coordinate matches; flags the rest.
+- `.github/actions/build/expo/action.yml` — selects latest Xcode, yalc-links the
+  plugin into CTExample, writes valid CI service stubs + normalizes account values,
+  runs `expo prebuild`, COMPILE-ONLY builds Android (`gradlew assembleDebug`) + iOS
+  (`xcodebuild build`), then **restores CI-mutated files + removes yalc artifacts**
+  so the commit contains only real source edits. No emulator/simulator boot.
+- `prompts/pr-description-expo.md` — renders the Expo PR body, incl. a **collapsible
+  full-changelog** reviewer section (RN/Android/iOS target+intermediates; Expo as links).
+
+## Files the robot edits each run
+
+`src/android_config/utility/constants.ts` (version pins),
+`src/android_config/utility/androidAppDepsTemplate.ts` (+ `types/androidTypes.ts`,
+for new compileOnly deps), `src/android_config/gradle/withCleverTapAndroidAppRootBuildGradle.ts`
+(classpaths), `android/build.gradle` (push-templates pin),
+`src/iOS_config/IOSConstants.ts` + `ios/ExpoAdapterCleverTap.podspec` (iOS
+deployment target), `CTExample/{app.json,package.json}` and
+`CTExample/{constants.js,App.js,app-utils.js}` (new-API demos), `README.md` (compat
+matrix), `CHANGELOG.md`, `package.json` (plugin version).
+
+## Runner / timing
+
+- Runs on **`macos-15`** (the Expo dispatch passes `runs_on: macos-15`) — Expo
+  SDK 55+/RN 0.83+ need a newer Xcode/Swift (e.g. Xcode 26.x) than `macos-14` has,
+  to build `expo-modules-core`. `latest-stable` Xcode is selected in the build.
+- Job timeout is **180 min** — Expo does TWO full compiles (pre- + post-sync) plus
+  the Claude run; iOS `xcodebuild` alone is ~30 min each.
+
+## Required repo secrets
+
+`CLEVERTAP_WRAPPER_SYNC_APP_ID`, `CLEVERTAP_WRAPPER_SYNC_PRIVATE_KEY`,
+`ANTHROPIC_API_KEY` (same `clevertap-wrapper-sync` App as the other wrappers).
+`SLACK_WEBHOOK_URL` is optional. The App needs **Contents: write** +
+**Pull requests: write**.
+
+## Testing (fork-based — see the hub's TESTING.md)
+
+1. Fork this repo. Put the dispatch workflow + skills on a branch (e.g.
+   `task/setup-sync-automation`) and set it as the fork's default branch so the Run
+   button appears. The skills must live on the `base_ref` branch the sync checks out.
+2. Install the App on the fork + add the secrets.
+3. First run with `skip_sync=true` ($0 — validates setup + build/expo).
+4. Then a real run (`skip_sync=false`); the robot auto-creates `task/release_<name>`
+   from `base_ref` and opens a PR back against it. Use a unique `release_name`.
+   For testing the hub itself, pass `tooling_ref: <hub-branch>` so the hub's
+   composite actions/prompts/tools come from that branch (not the default).
+5. Iterate the hub via the moving `@v1` tag, or via `tooling_ref` for a branch.
+
+## Known traps (all handled in the implementation)
+
+- **PR never opens:** `sync.yml`'s commit/push/PR conditions must include
+  `sync_expo.outcome` — Expo's `sync_android`/`sync_ios` steps are skipped.
+- **Tooling checkout ref:** the conductor checks out the hub at `inputs.tooling_ref
+  || github.job_workflow_sha` (the latter is empty for `workflow_dispatch` reusable
+  calls — hence the explicit `tooling_ref` override for testing).
+- **macOS/Xcode:** Expo 55+/RN 0.83+ iOS won't build on macos-14 (Swift 6 errors in
+  expo-modules-core) — use macos-15 + latest Xcode.
+- **App-token TTL:** the setup token (1 hr) expires during the ~90-min run, so a
+  FRESH token is minted right before push/PR, with explicit
+  `permission-contents:write` + `permission-pull-requests:write`; the push also
+  clears `actions/checkout`'s stale `http.extraheader` before re-auth.
+- **Clean PR:** build/expo backs up + restores CI-mutated files (`app.json`,
+  `google-services.json`, `agconnect-services.json`) and removes `.yalc`/`yalc.lock`
+  so they don't pollute the commit; CTExample account placeholders ("YOUR ACCT ID",
+  which contain spaces) are normalized to space-free CI values so the iOS pbxproj parses.
+- **Tags / branches:** `expo_diff.py` resolves combined Android tags (e.g.
+  `corev7.6.0_ptv2.2.0`) via the GitHub tags API; `GITHUB_TOKEN` is passed to avoid
+  the anon rate limit. The clevertap-react-native / android-sdk default branch is
+  `master`, not `main`. RN tags are bare `X.Y.Z`.
+- **Versions come ONLY from `expo_diff.json`;** WebFetch (Expo-only) is for reading
+  integration-step docs + Expo notes, never for version numbers.
+
+## Production cutover (remaining)
+
+1. In the spoke dispatch, flip `uses:` `@task/expo-wrapper-sync` → **`@v1`**; remove
+   the test-only `tooling_ref`; **keep `runs_on: macos-15`**.
+2. PR this branch (dispatch workflow + `.claude/skills`) → the real
+   `CleverTap/clevertap-expo-plugin` `develop`.
+3. Merge the hub branch `task/expo-wrapper-sync` to the hub default branch and move
+   the `v1` tag.
+4. Install the App + add the secrets on the real `clevertap-expo-plugin`.


### PR DESCRIPTION
## Summary

Wires `clevertap-expo-plugin` into the central **wrapper-sync** automation. Unlike the native bridges, the Expo plugin is a **config plugin** (surfaces no SDK methods) — so a maintainer triggers `native-release-sync` with a target **clevertap-react-native** version + **Expo SDK** version, and a headless run (`CleverTap/clevertap-wrapper-tooling@v1`) bumps dependency pins, propagates native-integration-step + iOS-deployment changes, showcases new clevertap-react-native APIs as demo buttons in CTExample, updates the compat matrix + CHANGELOG, compiles CTExample, and opens a review PR.

Validated end-to-end on a fork (RN 4.1.0/Expo 55 and RN 4.2.0/Expo 56, sonnet + opus).

## Changes
- `.github/workflows/native-release-sync.yml` — manual `workflow_dispatch` → reusable `sync.yml@v1` with `wrapper: expo`, `runs_on: macos-15` (Expo 55+/RN 0.83+ need a newer Xcode/Swift to build `expo-modules-core`), + the four secrets.
- `.github/CODEOWNERS` — review owners for the bot's PRs.
- `.claude/skills/` — comprehensive, self-discovering sync skills (cover all SDKs + iOS + integration-step reasoning) plus the architecture and device-testing skills.
- `WRAPPER_SYNC_HANDOFF.md` — operator/handoff reference.

Example-app build output (`CTExample/android`, `CTExample/ios`) is already gitignored; the build composite removes `.yalc`/`yalc.lock`, so sync PRs stay clean.


> Note: the "Run workflow" button appears once this reaches the default branch (`main`) via the normal develop→main flow; until then trigger via `gh workflow run native-release-sync.yml --ref develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)